### PR TITLE
fix: debounce speed notification channel selection to stop flapping

### DIFF
--- a/app/src/main/java/com/leekleak/trafficlight/services/notifications/SpeedNotification.kt
+++ b/app/src/main/java/com/leekleak/trafficlight/services/notifications/SpeedNotification.kt
@@ -134,7 +134,16 @@ class SpeedNotification(
             context.getString(R.string.wi_fi, DataSize(todayUsage.usage2).toString(metric = sizeMetric)).clipAndPad(spacing) +
             context.getString(R.string.mobile, DataSize(todayUsage.usage1).toString(metric = sizeMetric))
 
-        if (lastTitle == data && lastContent == messageShort && !force) return
+        // Advance the channel hysteresis every tick, before the content early-return below.
+        // Otherwise a steady speed that produces identical text would short-circuit and the
+        // streak would never accumulate, leaving the notification stuck on the old channel
+        // after a real threshold crossing. Re-post if the channel actually changed even when
+        // the text is unchanged.
+        val previousChannel = currentChannel
+        resolveChannel(immediate = force)
+        val channelChanged = currentChannel != previousChannel
+
+        if (lastTitle == data && lastContent == messageShort && !channelChanged && !force) return
         lastTitle = data
         lastContent = messageShort
 
@@ -176,16 +185,56 @@ class SpeedNotification(
         todayUsage = DayUsage(date, mobile, wifi)
     }
 
+    // Retained channel-selection state for hysteresis (see chooseChannel). `currentChannel`
+    // is the channel the notification is currently posted on (null before the first post);
+    // `pendingChannel`/`pendingStreak` track how long the instantaneous decision has wanted
+    // to switch away from `currentChannel`.
+    private var currentChannel: String? = null
+    private var pendingChannel: String? = null
+    private var pendingStreak = 0
+
+    /**
+     * Advances the hysteresis state for one update tick and returns the channel the notification
+     * should be posted on. This is the only place the streak state mutates, so it must be called
+     * exactly once per update tick (see [updateNotification]). It is intentionally cheap (no
+     * builder allocation) so it can run on every tick, including the ones whose textual content
+     * is unchanged and would otherwise short-circuit before the notification is rebuilt.
+     *
+     * Pass [immediate] for forced updates (e.g. the user toggling `speedThreshold` or changing
+     * `speedThresholdKb`): the new preference is adopted at once and the debounce is reset, so a
+     * settings change takes effect immediately rather than after the hysteresis window. Hysteresis
+     * is only meant to absorb tick-by-tick speed oscillation, not deliberate setting changes.
+     */
+    private fun resolveChannel(immediate: Boolean = false): String {
+        // Instantaneous channel preference from the current sample, preserving the original
+        // precedence: silent when the threshold feature is on AND either (the -1L "no network"
+        // setting and no network is available) OR the current speed is below the threshold.
+        val instantaneousSilent = speedThreshold &&
+            (
+                ((speedThresholdKb == -1L) && !isNetworkAvailable()) ||
+                (trafficSnapshot.totalSpeed.toKb < speedThresholdKb)
+            )
+
+        // Passing currentChannel = null reuses chooseChannel's "first post" path, which adopts the
+        // instantaneous preference directly and clears the streak.
+        val decision = chooseChannel(
+            speedThresholdEnabled = speedThreshold,
+            instantaneousSilent = instantaneousSilent,
+            currentChannel = if (immediate) null else currentChannel,
+            streakChannel = pendingChannel,
+            streak = pendingStreak,
+            hysteresisTicks = CHANNEL_HYSTERESIS_TICKS,
+        )
+        currentChannel = decision.channel
+        pendingChannel = decision.streakChannel
+        pendingStreak = decision.streak
+        return decision.channel
+    }
+
     private fun updateBaseNotification() {
-        val channel = when {
-            (speedThreshold &&
-                (
-                    (speedThresholdKb == -1L) && !isNetworkAvailable() ||
-                    (trafficSnapshot.totalSpeed.toKb < speedThresholdKb)
-                )
-            ) -> NOTIFICATION_CHANNEL_ID_SILENT
-            else -> NOTIFICATION_CHANNEL_ID
-        }
+        // Use the channel already resolved for this tick; only resolve here for the very first
+        // post (init), so the hysteresis streak is never advanced twice in a single tick.
+        val channel = currentChannel ?: resolveChannel()
         notificationBuilder = NotificationCompat.Builder(context, channel)
             .setSmallIcon(R.drawable.notification)
             .setContentTitle(context.getString(R.string.app_name_short))
@@ -227,7 +276,72 @@ class SpeedNotification(
 
     companion object {
         private const val DATA_UPDATE_FREQ = 4
+
+        /**
+         * Number of consecutive update ticks the instantaneous channel preference must disagree
+         * with the currently-posted channel before the notification is actually moved. At ~900ms
+         * per tick this debounces the loud/silent switch over a short window so that a speed
+         * oscillating right around the threshold no longer re-posts (and visibly "blinks") the
+         * notification every tick. See issue #181 (regression from #177).
+         */
+        const val CHANNEL_HYSTERESIS_TICKS = 3
+
         const val NOTIFICATION_CHANNEL_ID = "Persistent Notification"
         const val NOTIFICATION_CHANNEL_ID_SILENT = "Persistent Notification Silent"
+
+        /**
+         * Result of a hysteresis-aware channel decision: the channel to post on now, plus the
+         * retained streak state to feed back into the next [chooseChannel] call.
+         */
+        data class ChannelDecision(
+            val channel: String,
+            val streakChannel: String?,
+            val streak: Int,
+        )
+
+        /**
+         * Pure channel-selection helper with hysteresis. Given the instantaneous channel
+         * preference and the retained streak state, returns the channel to post on plus the
+         * updated streak state.
+         *
+         * Rules:
+         *  - threshold feature disabled -> always the loud channel, streak cleared.
+         *  - first post (currentChannel == null) -> adopt the instantaneous preference immediately.
+         *  - instantaneous preference matches the current channel -> hold it, streak cleared.
+         *  - instantaneous preference differs -> count consecutive ticks; only switch once the
+         *    preference has held for [hysteresisTicks] ticks, otherwise keep the current channel.
+         */
+        fun chooseChannel(
+            speedThresholdEnabled: Boolean,
+            instantaneousSilent: Boolean,
+            currentChannel: String?,
+            streakChannel: String?,
+            streak: Int,
+            hysteresisTicks: Int = CHANNEL_HYSTERESIS_TICKS,
+        ): ChannelDecision {
+            if (!speedThresholdEnabled) {
+                return ChannelDecision(NOTIFICATION_CHANNEL_ID, null, 0)
+            }
+
+            val desired = if (instantaneousSilent) NOTIFICATION_CHANNEL_ID_SILENT else NOTIFICATION_CHANNEL_ID
+
+            // First post: there is nothing to flap away from, so adopt the preference directly.
+            if (currentChannel == null) {
+                return ChannelDecision(desired, null, 0)
+            }
+
+            // Preference agrees with what is shown: nothing to switch, drop any pending streak.
+            if (desired == currentChannel) {
+                return ChannelDecision(currentChannel, null, 0)
+            }
+
+            // Preference wants to switch: require it to persist for `hysteresisTicks` ticks.
+            val newStreak = if (streakChannel == desired) streak + 1 else 1
+            return if (newStreak >= hysteresisTicks) {
+                ChannelDecision(desired, null, 0)
+            } else {
+                ChannelDecision(currentChannel, desired, newStreak)
+            }
+        }
     }
 }

--- a/app/src/test/java/com/leekleak/trafficlight/services/notifications/SpeedNotificationChannelTest.kt
+++ b/app/src/test/java/com/leekleak/trafficlight/services/notifications/SpeedNotificationChannelTest.kt
@@ -1,0 +1,153 @@
+package com.leekleak.trafficlight.services.notifications
+
+import com.leekleak.trafficlight.services.notifications.SpeedNotification.Companion.ChannelDecision
+import com.leekleak.trafficlight.services.notifications.SpeedNotification.Companion.NOTIFICATION_CHANNEL_ID
+import com.leekleak.trafficlight.services.notifications.SpeedNotification.Companion.NOTIFICATION_CHANNEL_ID_SILENT
+import com.leekleak.trafficlight.services.notifications.SpeedNotification.Companion.chooseChannel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [SpeedNotification.chooseChannel], the hysteresis-aware channel selector that
+ * fixes the speed-notification "blinking" between the loud and silent channels reported in
+ * issue #181 (a regression from PR #177).
+ *
+ * The helper is pure, so these tests drive it directly without constructing a SpeedNotification
+ * or any Android framework objects.
+ */
+class SpeedNotificationChannelTest {
+
+    private val ticks = 3
+
+    /** Convenience: run one tick, returning the resulting decision. */
+    private fun tick(
+        instantaneousSilent: Boolean,
+        prev: ChannelDecision,
+        thresholdEnabled: Boolean = true,
+    ): ChannelDecision = chooseChannel(
+        speedThresholdEnabled = thresholdEnabled,
+        instantaneousSilent = instantaneousSilent,
+        currentChannel = prev.channel,
+        streakChannel = prev.streakChannel,
+        streak = prev.streak,
+        hysteresisTicks = ticks,
+    )
+
+    private fun firstPost(instantaneousSilent: Boolean, thresholdEnabled: Boolean = true) =
+        chooseChannel(
+            speedThresholdEnabled = thresholdEnabled,
+            instantaneousSilent = instantaneousSilent,
+            currentChannel = null,
+            streakChannel = null,
+            streak = 0,
+            hysteresisTicks = ticks,
+        )
+
+    @Test
+    fun `steady above threshold holds the loud channel`() {
+        var d = firstPost(instantaneousSilent = false)
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+        repeat(10) {
+            d = tick(instantaneousSilent = false, prev = d)
+            assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+        }
+    }
+
+    @Test
+    fun `steady below threshold holds the silent channel`() {
+        var d = firstPost(instantaneousSilent = true)
+        assertEquals(NOTIFICATION_CHANNEL_ID_SILENT, d.channel)
+        repeat(10) {
+            d = tick(instantaneousSilent = true, prev = d)
+            assertEquals(NOTIFICATION_CHANNEL_ID_SILENT, d.channel)
+        }
+    }
+
+    @Test
+    fun `tick-by-tick oscillation around the threshold does not flap the channel`() {
+        // Start steadily on the loud channel.
+        var d = firstPost(instantaneousSilent = false)
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+
+        // Now alternate below/above every tick (the regression scenario). Because the silent
+        // preference never persists for `ticks` consecutive ticks, the channel must never move.
+        var silent = true
+        repeat(20) {
+            d = tick(instantaneousSilent = silent, prev = d)
+            assertEquals(
+                "channel must not change while oscillating around the threshold",
+                NOTIFICATION_CHANNEL_ID,
+                d.channel,
+            )
+            silent = !silent
+        }
+    }
+
+    @Test
+    fun `channel switches only after the preference persists for the full debounce window`() {
+        var d = firstPost(instantaneousSilent = false)
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+
+        // Two consecutive silent ticks: not enough yet, still loud.
+        d = tick(instantaneousSilent = true, prev = d)
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+        d = tick(instantaneousSilent = true, prev = d)
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+
+        // Third consecutive silent tick reaches the window: switch to silent.
+        d = tick(instantaneousSilent = true, prev = d)
+        assertEquals(NOTIFICATION_CHANNEL_ID_SILENT, d.channel)
+    }
+
+    @Test
+    fun `an interrupting opposite sample resets the debounce streak`() {
+        var d = firstPost(instantaneousSilent = false)
+
+        // Two silent, then one loud interrupts -> streak resets, still loud.
+        d = tick(instantaneousSilent = true, prev = d)
+        d = tick(instantaneousSilent = true, prev = d)
+        d = tick(instantaneousSilent = false, prev = d)
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+
+        // Need a fresh run of `ticks` silent samples to switch.
+        d = tick(instantaneousSilent = true, prev = d)
+        d = tick(instantaneousSilent = true, prev = d)
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+        d = tick(instantaneousSilent = true, prev = d)
+        assertEquals(NOTIFICATION_CHANNEL_ID_SILENT, d.channel)
+    }
+
+    @Test
+    fun `single transient sample does not flip the channel (disconnected -1L case)`() {
+        // Models speedThresholdKb == -1L: instantaneousSilent reflects "no network available".
+        var d = firstPost(instantaneousSilent = false) // network available -> loud
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+
+        // A single transient "unavailable" sample must not immediately flip to silent.
+        d = tick(instantaneousSilent = true, prev = d)
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+
+        // Recovering immediately keeps it loud.
+        d = tick(instantaneousSilent = false, prev = d)
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+    }
+
+    @Test
+    fun `threshold disabled always selects the loud channel and never engages hysteresis`() {
+        var d = firstPost(instantaneousSilent = true, thresholdEnabled = false)
+        assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+        assertEquals(0, d.streak)
+
+        repeat(5) {
+            d = tick(instantaneousSilent = true, prev = d, thresholdEnabled = false)
+            assertEquals(NOTIFICATION_CHANNEL_ID, d.channel)
+            assertEquals(0, d.streak)
+        }
+    }
+
+    @Test
+    fun `first post chooses the correct channel without an extra flip`() {
+        assertEquals(NOTIFICATION_CHANNEL_ID_SILENT, firstPost(instantaneousSilent = true).channel)
+        assertEquals(NOTIFICATION_CHANNEL_ID, firstPost(instantaneousSilent = false).channel)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the speed notification "blinking" between the loud and silent channels reported by Onxr in the v3.0 prerelease thread (#181, reconfirmed in alpha3). `SpeedNotification` re-selected its notification channel on every ~900ms update tick. Because a notification cannot be moved between channels in place, each channel change cancels and re-posts it, so when the live speed oscillates right around `speedThresholdKb` the channel flips every tick and the notification visibly blinks between "Persistent Notification" and "Persistent Notification (silent)".

The channel decision is now a pure `chooseChannel()` helper with hysteresis: the channel only switches after the instantaneous preference has held for `CHANNEL_HYSTERESIS_TICKS` (3) consecutive ticks, so transient oscillation around the threshold no longer re-posts the notification. The builder configuration (`setSilent`, `setOnlyAlertOnce`, etc.) is unchanged - only the channel-selection cadence changes.

## Why this matters

This is a regression from #177 ("add option for low-speed channel"), which introduced posting the ongoing notification on one of two channels based on current speed. The instantaneous per-tick decision is correct in steady state but flaps whenever the speed sits near the threshold, which is exactly when the low-speed option is most likely to be in use.

Two edges are handled so the fix doesn't introduce its own regressions:

- The hysteresis state is advanced every tick, before the existing "unchanged text" early-return in `updateNotification()`, so a steady speed that crosses the threshold and then holds an identical formatted value still resolves to the new channel instead of getting stuck on the old one.
- Forced updates (the user toggling `speedThreshold` or changing `speedThresholdKb`) bypass the debounce and take effect immediately, preserving the previous "settings change applies at once" behavior. Hysteresis only absorbs tick-by-tick speed sampling, not deliberate setting changes.

## Testing

Adds `SpeedNotificationChannelTest`, driving the pure `chooseChannel()` helper directly (no Android framework objects needed):

- Steady above / below threshold -> loud / silent channel selected and held.
- Tick-by-tick oscillation around the threshold -> channel never changes (the regression guard).
- Channel switches only after the preference persists for the full debounce window; an interrupting opposite sample resets the streak.
- `speedThresholdKb == -1L` disconnected case -> a single transient unavailable sample does not flip the channel.
- `speedThreshold` disabled -> always loud, hysteresis never engaged.
- First post -> chooses the correct channel without an extra flip.

Refs #181 (the issue is a multi-report megathread; this PR addresses only the channel-flapping report).
