### PR TITLE
feat: show today's up/down/total split by Cellular and Wi-Fi on overview

### DIFF
--- a/app/src/main/java/com/leekleak/trafficlight/ui/overview/Overview.kt
+++ b/app/src/main/java/com/leekleak/trafficlight/ui/overview/Overview.kt
@@ -84,6 +84,7 @@ import com.leekleak.trafficlight.util.MiniCard
 import com.leekleak.trafficlight.util.MiniCardState
 import com.leekleak.trafficlight.util.PageTitle
 import com.leekleak.trafficlight.util.TrendCard
+import com.leekleak.trafficlight.util.formatted
 import com.leekleak.trafficlight.util.formattedParts
 import com.leekleak.trafficlight.util.iconToggleButton
 import com.leekleak.trafficlight.util.px
@@ -368,6 +369,7 @@ fun OverviewItems() {
     val data by viewModel.weekUsage.collectAsState()
     val topAppsList by viewModel.topApps.collectAsState()
     val query by viewModel.query.collectAsState()
+    TodayBreakdownCard()
     CategoryTitleText(stringResource(R.string.top_apps))
     Box(
         modifier = Modifier
@@ -391,4 +393,101 @@ fun OverviewItems() {
             BarGraph(data)
         }
     }
+}
+
+@Composable
+private fun TodayBreakdownCard() {
+    val viewModel: OverviewVM = koinViewModel()
+    val breakdown by viewModel.todayBreakdown.collectAsState()
+
+    CategoryTitleText(stringResource(R.string.today_by_transport))
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .card()
+            .padding(12.dp)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            TodayBreakdownHeader()
+            TodayBreakdownRow(stringResource(R.string.cellular), breakdown.cellular)
+            TodayBreakdownRow(stringResource(R.string.wifi), breakdown.wifi)
+        }
+    }
+}
+
+@Composable
+private fun TodayBreakdownHeader() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "",
+            modifier = Modifier.weight(0.9f),
+        )
+        TodayBreakdownHeaderText(
+            text = stringResource(R.string.download),
+            modifier = Modifier.weight(1f),
+        )
+        TodayBreakdownHeaderText(
+            text = stringResource(R.string.upload),
+            modifier = Modifier.weight(1f),
+        )
+        TodayBreakdownHeaderText(
+            text = stringResource(R.string.total),
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun TodayBreakdownHeaderText(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = colorScheme.onSurfaceVariant,
+        fontSize = 12.sp,
+        textAlign = TextAlign.End,
+    )
+}
+
+@Composable
+private fun TodayBreakdownRow(label: String, usage: TransportUsage) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.weight(0.9f),
+            fontSize = 14.sp,
+        )
+        TodayBreakdownValue(
+            value = DataSize(usage.download).formatted(extraPrecision = true),
+            modifier = Modifier.weight(1f),
+        )
+        TodayBreakdownValue(
+            value = DataSize(usage.upload).formatted(extraPrecision = true),
+            modifier = Modifier.weight(1f),
+        )
+        TodayBreakdownValue(
+            value = DataSize(usage.total).formatted(extraPrecision = true),
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun TodayBreakdownValue(value: String, modifier: Modifier = Modifier) {
+    Text(
+        text = value,
+        modifier = modifier,
+        fontSize = 14.sp,
+        textAlign = TextAlign.End,
+    )
 }

--- a/app/src/main/java/com/leekleak/trafficlight/ui/overview/OverviewLogic.kt
+++ b/app/src/main/java/com/leekleak/trafficlight/ui/overview/OverviewLogic.kt
@@ -2,6 +2,7 @@ package com.leekleak.trafficlight.ui.overview
 
 import com.leekleak.trafficlight.charts.model.BarData
 import com.leekleak.trafficlight.database.AppUsage
+import com.leekleak.trafficlight.database.DataDirection
 import com.leekleak.trafficlight.database.DataType
 import com.leekleak.trafficlight.database.UsageQuery
 import com.leekleak.trafficlight.model.AppManager.Companion.allApp
@@ -14,6 +15,19 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.math.max
 import kotlin.math.roundToInt
+
+data class TransportUsage(
+    val download: Long = 0,
+    val upload: Long = 0,
+) {
+    val total: Long
+        get() = download + upload
+}
+
+data class TodayBreakdown(
+    val cellular: TransportUsage = TransportUsage(),
+    val wifi: TransportUsage = TransportUsage(),
+)
 
 class OverviewLogic(val networkUsageManager: NetworkUsageManager) {
     suspend fun getPrediction(query: UsageQuery): Long {
@@ -62,6 +76,27 @@ class OverviewLogic(val networkUsageManager: NetworkUsageManager) {
 
     suspend fun getTodayUsage(query: UsageQuery): Long {
         return networkUsageManager.totalDayUsage(query, LocalDate.now())
+    }
+
+    suspend fun getTodayBreakdown(): TodayBreakdown {
+        val today = LocalDate.now()
+        return TodayBreakdown(
+            cellular = getTransportUsage(DataType.Mobile, today),
+            wifi = getTransportUsage(DataType.Wifi, today),
+        )
+    }
+
+    private suspend fun getTransportUsage(dataType: DataType, date: LocalDate): TransportUsage {
+        return TransportUsage(
+            download = networkUsageManager.totalDayUsage(
+                UsageQuery(dataType, DataDirection.Download),
+                date,
+            ),
+            upload = networkUsageManager.totalDayUsage(
+                UsageQuery(dataType, DataDirection.Upload),
+                date,
+            ),
+        )
     }
 
     suspend fun getTrend(query: UsageQuery): Int {

--- a/app/src/main/java/com/leekleak/trafficlight/ui/overview/OverviewLogic.kt
+++ b/app/src/main/java/com/leekleak/trafficlight/ui/overview/OverviewLogic.kt
@@ -2,7 +2,6 @@ package com.leekleak.trafficlight.ui.overview
 
 import com.leekleak.trafficlight.charts.model.BarData
 import com.leekleak.trafficlight.database.AppUsage
-import com.leekleak.trafficlight.database.DataDirection
 import com.leekleak.trafficlight.database.DataType
 import com.leekleak.trafficlight.database.UsageQuery
 import com.leekleak.trafficlight.model.AppManager.Companion.allApp
@@ -87,15 +86,13 @@ class OverviewLogic(val networkUsageManager: NetworkUsageManager) {
     }
 
     private suspend fun getTransportUsage(dataType: DataType, date: LocalDate): TransportUsage {
+        val startStamp = date.toTimestamp()
+        val endStamp = date.plusDays(1).toTimestamp()
+        val usage = networkUsageManager.getNetworkDataForType(startStamp, endStamp, null, dataType)
+
         return TransportUsage(
-            download = networkUsageManager.totalDayUsage(
-                UsageQuery(dataType, DataDirection.Download),
-                date,
-            ),
-            upload = networkUsageManager.totalDayUsage(
-                UsageQuery(dataType, DataDirection.Upload),
-                date,
-            ),
+            download = usage.sumOf { it.download },
+            upload = usage.sumOf { it.upload },
         )
     }
 

--- a/app/src/main/java/com/leekleak/trafficlight/ui/overview/OverviewVM.kt
+++ b/app/src/main/java/com/leekleak/trafficlight/ui/overview/OverviewVM.kt
@@ -43,6 +43,9 @@ class OverviewVM(
     val todayUsage = refresh.map { overviewLogic.getTodayUsage(it) }.distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
 
+    val todayBreakdown = refresh.map { overviewLogic.getTodayBreakdown() }.distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), TodayBreakdown())
+
     val prediction = refresh.map { overviewLogic.getPrediction(it) }.distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,8 @@
     <string name="secondary">Secondary</string>
     <string name="upload">Upload</string>
     <string name="download">Download</string>
+    <string name="total">Total</string>
+    <string name="today_by_transport">Today by transport</string>
     <string name="bidirectional">Bidirectional</string>
     <string name="app_list">App list</string>
     <string name="hour_list">Hour list</string>

--- a/app/src/test/java/com/leekleak/trafficlight/ui/overview/OverviewLogicTest.kt
+++ b/app/src/test/java/com/leekleak/trafficlight/ui/overview/OverviewLogicTest.kt
@@ -1,0 +1,161 @@
+package com.leekleak.trafficlight.ui.overview
+
+import android.app.usage.NetworkStats
+import android.app.usage.NetworkStatsManager
+import com.leekleak.trafficlight.model.AppManager
+import com.leekleak.trafficlight.model.NetworkUsageManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.TimeZone
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class OverviewLogicTest {
+
+    private lateinit var networkStatsManager: NetworkStatsManager
+    private lateinit var appManager: AppManager
+    private lateinit var overviewLogic: OverviewLogic
+
+    @Before
+    fun setUp() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        networkStatsManager = mockk(relaxed = true)
+        appManager = mockk(relaxed = true)
+        overviewLogic = OverviewLogic(NetworkUsageManager(networkStatsManager, appManager))
+    }
+
+    @Test
+    fun `getTodayBreakdown returns download upload and total for each transport`() = runTest {
+        stubUsage(
+            mobileBuckets = listOf(UsageBucket(txBytes = 1_200L, rxBytes = 3_400L)),
+            wifiBuckets = listOf(UsageBucket(txBytes = 5_600L, rxBytes = 7_800L)),
+        )
+
+        val result = overviewLogic.getTodayBreakdown()
+
+        assertEquals(3_400L, result.cellular.download)
+        assertEquals(1_200L, result.cellular.upload)
+        assertEquals(4_600L, result.cellular.total)
+        assertEquals(7_800L, result.wifi.download)
+        assertEquals(5_600L, result.wifi.upload)
+        assertEquals(13_400L, result.wifi.total)
+    }
+
+    @Test
+    fun `getTodayBreakdown totals are derived without extra bidirectional queries`() = runTest {
+        stubUsage(
+            mobileBuckets = listOf(UsageBucket(txBytes = 10L, rxBytes = 20L)),
+            wifiBuckets = listOf(UsageBucket(txBytes = 30L, rxBytes = 40L)),
+        )
+
+        val result = overviewLogic.getTodayBreakdown()
+
+        assertEquals(result.cellular.download + result.cellular.upload, result.cellular.total)
+        assertEquals(result.wifi.download + result.wifi.upload, result.wifi.total)
+        verify(exactly = 2) { networkStatsManager.querySummary(MOBILE_QUERY_INDEX, null, any(), any()) }
+        verify(exactly = 2) { networkStatsManager.querySummary(WIFI_QUERY_INDEX, null, any(), any()) }
+    }
+
+    @Test
+    fun `getTodayBreakdown returns zero usage when no buckets exist`() = runTest {
+        stubUsage()
+
+        val result = overviewLogic.getTodayBreakdown()
+
+        assertEquals(0L, result.cellular.download)
+        assertEquals(0L, result.cellular.upload)
+        assertEquals(0L, result.cellular.total)
+        assertEquals(0L, result.wifi.download)
+        assertEquals(0L, result.wifi.upload)
+        assertEquals(0L, result.wifi.total)
+    }
+
+    private fun stubUsage(
+        mobileBuckets: List<UsageBucket> = emptyList(),
+        wifiBuckets: List<UsageBucket> = emptyList(),
+    ) {
+        every { networkStatsManager.querySummary(MOBILE_QUERY_INDEX, null, any(), any()) } answers {
+            summaryWithBuckets(mobileBuckets)
+        }
+        every { networkStatsManager.querySummary(WIFI_QUERY_INDEX, null, any(), any()) } answers {
+            summaryWithBuckets(wifiBuckets)
+        }
+        every { networkStatsManager.querySummaryForDevice(MOBILE_QUERY_INDEX, null, any(), any()) } answers {
+            deviceBucketFor(mobileBuckets)
+        }
+        every { networkStatsManager.querySummaryForDevice(WIFI_QUERY_INDEX, null, any(), any()) } answers {
+            deviceBucketFor(wifiBuckets)
+        }
+    }
+
+    private fun summaryWithBuckets(buckets: List<UsageBucket>): NetworkStats {
+        val summary = mockk<NetworkStats>(relaxed = true)
+        var bucketCount = 0
+        val bucketSlot = slot<NetworkStats.Bucket>()
+        every { summary.hasNextBucket() } answers { bucketCount < buckets.size }
+        every { summary.getNextBucket(capture(bucketSlot)) } answers {
+            val usage = buckets[bucketCount]
+            setBucketFields(
+                bucketSlot.captured,
+                uid = usage.uid,
+                txBytes = usage.txBytes,
+                rxBytes = usage.rxBytes,
+            )
+            bucketCount++
+            true
+        }
+        return summary
+    }
+
+    private fun deviceBucketFor(buckets: List<UsageBucket>): NetworkStats.Bucket {
+        val bucket = NetworkStats.Bucket()
+        setBucketFields(
+            bucket,
+            uid = -1,
+            txBytes = buckets.sumOf { it.txBytes },
+            rxBytes = buckets.sumOf { it.rxBytes },
+        )
+        return bucket
+    }
+
+    /**
+     * Helper to set private/final fields on NetworkStats.Bucket using reflection.
+     * This is necessary because Robolectric's shadow for Bucket doesn't always expose
+     * setters for all fields across all SDK versions.
+     */
+    private fun setBucketFields(bucket: NetworkStats.Bucket, uid: Int, txBytes: Long, rxBytes: Long) {
+        val fields = NetworkStats.Bucket::class.java.declaredFields
+        fields.forEach { field ->
+            field.isAccessible = true
+            try {
+                when (field.name) {
+                    "uid", "mUid" -> field.set(bucket, uid)
+                    "txBytes", "mTxBytes" -> field.set(bucket, txBytes)
+                    "rxBytes", "mRxBytes" -> field.set(bucket, rxBytes)
+                }
+            } catch (e: Exception) {
+                // Ignore if field doesn't exist in this Android version
+            }
+        }
+    }
+
+    private data class UsageBucket(
+        val uid: Int = 1001,
+        val txBytes: Long,
+        val rxBytes: Long,
+    )
+
+    private companion object {
+        const val MOBILE_QUERY_INDEX = 0
+        const val WIFI_QUERY_INDEX = 1
+    }
+}

--- a/app/src/test/java/com/leekleak/trafficlight/ui/overview/OverviewLogicTest.kt
+++ b/app/src/test/java/com/leekleak/trafficlight/ui/overview/OverviewLogicTest.kt
@@ -61,8 +61,8 @@ class OverviewLogicTest {
 
         assertEquals(result.cellular.download + result.cellular.upload, result.cellular.total)
         assertEquals(result.wifi.download + result.wifi.upload, result.wifi.total)
-        verify(exactly = 2) { networkStatsManager.querySummary(MOBILE_QUERY_INDEX, null, any(), any()) }
-        verify(exactly = 2) { networkStatsManager.querySummary(WIFI_QUERY_INDEX, null, any(), any()) }
+        verify(exactly = 1) { networkStatsManager.querySummary(MOBILE_QUERY_INDEX, null, any(), any()) }
+        verify(exactly = 1) { networkStatsManager.querySummary(WIFI_QUERY_INDEX, null, any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds a compact "Today by transport" card to the Overview page that shows today's Download, Upload, and Total split into two rows: Cellular and Wi-Fi. This surfaces the per-transport daily send/receive totals the issue asked for, while keeping the overview layout minimal.

## Why this matters

The overview previously showed only the weekly bar graph and a single today figure, with no per-transport split. Issue #178 asked to see today's Upload / Download / Total separated for Cellular and Wi-Fi at a glance.

The breakdown is computed in `OverviewLogic.getTodayBreakdown()`, which reads each transport's usage once for the current day and derives download/upload/total from that single `NetworkStats` scan (no double counting, no redundant queries). It is exposed from `OverviewVM` as a `todayBreakdown` flow keyed off the existing refresh trigger, and rendered by `TodayBreakdownCard` in `Overview.kt` following the existing card/section conventions. A transport with no usage today renders 0 B.

## Testing

Added `OverviewLogicTest` (Robolectric + MockK, mirroring the existing `NetworkUsageManagerTest`) covering: correct per-transport download/upload/total, total equals download + upload, single scan per transport, and the zero-usage case.

`./gradlew :app:testDebugUnitTest --tests "*OverviewLogicTest*"` could not be executed in this environment (no local JDK/Android SDK). The tests follow the repo's existing unit-test setup and assertions.

Fixes #178
