### PR TITLE
Fix <clinit>

### DIFF
--- a/app/src/main/java/com/leekleak/trafficlight/database/CryptoManager.kt
+++ b/app/src/main/java/com/leekleak/trafficlight/database/CryptoManager.kt
@@ -16,7 +16,9 @@ object CryptoManager {
     private const val ALGORITHM = "AES/GCM/NoPadding"
     private const val KEY_ALIAS = "data_plan_key"
     private const val HMAC_ALIAS = "hmac_key"
-    private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply {
+    load(this.getApplicationContext().getFilesDir() + File.separator + "keystore")
+}
 
     private val keyCache = ConcurrentHashMap<String, SecretKey>()
 

--- a/app/src/main/java/com/leekleak/trafficlight/database/CryptoManager.kt
+++ b/app/src/main/java/com/leekleak/trafficlight/database/CryptoManager.kt
@@ -16,8 +16,14 @@ object CryptoManager {
     private const val ALGORITHM = "AES/GCM/NoPadding"
     private const val KEY_ALIAS = "data_plan_key"
     private const val HMAC_ALIAS = "hmac_key"
-private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply {
+private val keyStore = KeyStore.getInstance("AndroidKeyStore")
+
+fun initKeyStore() {
     load(this.getApplicationContext().getFilesDir() + File.separator + "keystore")
+}
+
+private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply {
+    initKeyStore()
 }
 
     private val keyCache = ConcurrentHashMap<String, SecretKey>()


### PR DESCRIPTION
# Fix: `<clinit>`

## Explanation

The `load()` method is called on the `keyStore` object before it has been initialized, which causes the error.

---

## Modified Method

| Property | Value |
|---|---|
| Method | `<clinit>` |
| Class | `com.leekleak.trafficlight.database.CryptoManager` |
| File | `/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/com.leekleak.trafficlight_38.apk/app/src/main/java/com/leekleak/trafficlight/database/CryptoManager.kt` |
| Status | `SUCCESS` |

---

## Changed File

```text
/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/com.leekleak.trafficlight_38.apk/app/src/main/java/com/leekleak/trafficlight/database/CryptoManager.kt
```

---


## Validation Checklist

- [x] Method replaced in source file
- [x] Repository updated
- [x] Commit generated
- [ ] Manual review required
- [ ] CI validation pending

---

Repair Pipeline