### PR TITLE
fix: prevent VPN traffic double-counting

### DIFF
--- a/app/src/main/java/com/leekleak/trafficlight/database/AppPreferenceRepo.kt
+++ b/app/src/main/java/com/leekleak/trafficlight/database/AppPreferenceRepo.kt
@@ -38,9 +38,6 @@ class AppPreferenceRepo (
     val forceFallback: Flow<Boolean> = data.map { it[FORCE_FALLBACK] ?: false }.distinctUntilChanged()
     suspend fun setForceFallback(value: Boolean) = dataStore.edit { it[FORCE_FALLBACK] = value }
 
-    val altVpn: Flow<Boolean> = data.map { it[ALT_VPN_WORKAROUND] ?: false }.distinctUntilChanged()
-    suspend fun setAltVpn(value: Boolean) = dataStore.edit { it[ALT_VPN_WORKAROUND] = value }
-
     val liveNotification: Flow<Boolean> = data.map { it[LIVE_NOTIFICATION] ?: false }.distinctUntilChanged()
     suspend fun setLiveNotification(value: Boolean) = dataStore.edit { it[LIVE_NOTIFICATION] = value }
 
@@ -81,7 +78,6 @@ class AppPreferenceRepo (
         private val SPEED_BITS = booleanPreferencesKey("speed_bits")
         private val SEPARATE_UP_DOWN = booleanPreferencesKey("separate_up_down")
         private val FORCE_FALLBACK = booleanPreferencesKey("force_fallback")
-        private val ALT_VPN_WORKAROUND = booleanPreferencesKey("alt_vpn")
         private val SPEED_THRESHOLD = booleanPreferencesKey("speed_threshold")
         private val SPEED_THRESHOLD_KB = longPreferencesKey("speed_threshold_kb")
         private val SPEED_METRIC = booleanPreferencesKey("speed_metric")

--- a/app/src/main/java/com/leekleak/trafficlight/database/TrafficSnapshot.kt
+++ b/app/src/main/java/com/leekleak/trafficlight/database/TrafficSnapshot.kt
@@ -4,13 +4,13 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.TrafficStats
-import android.os.Build
+import android.os.SystemClock
 import com.leekleak.trafficlight.model.DataUID
 import com.leekleak.trafficlight.util.toLocaleHourString
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -42,6 +42,36 @@ data class HourUsage(
     }
 }
 
+/**
+ * Tracks device network throughput for the live speed notification.
+ *
+ * Measurement model
+ * ------------------
+ * "Speed" here means the rate of traffic actually crossing the device's physical
+ * radios (Wi-Fi / cellular / Ethernet), not the rate observed at any single
+ * interface. That distinction matters once a VPN (traditional, WireGuard, or a
+ * local/loopback VPN such as AdGuard) is active: a VPN adds a virtual `tun`-style
+ * interface that carries a second, parallel view of the same traffic. Summing
+ * every interface (what [TrafficStats.getTotalRxBytes] does) therefore counts
+ * VPN'd traffic twice - once on the physical interface, once on the tunnel - and
+ * inflates the displayed speed, often close to 2x.
+ *
+ * To avoid that, [regularUpdateSnapshot] sums counters only for interfaces that
+ * back a physical, non-VPN network ([physicalInterfaceNames]), discovered from
+ * [ConnectivityManager] rather than assumed names like "wlan0" or "tun0". A VPN's
+ * underlying Wi-Fi/cellular network is still reported by the platform as its own
+ * `Network` (without `TRANSPORT_VPN`) even while the VPN is active, so this
+ * naturally excludes tunnel traffic without ever needing to detect or name the
+ * VPN interface itself. It also means split tunneling, VPN reconnects, and VPN
+ * on/off transitions don't require any special-casing: the physical interfaces
+ * being summed don't change just because a VPN attaches to or detaches from them.
+ *
+ * Interface changes (Wi-Fi <-> mobile <-> Ethernet) *do* change which interfaces
+ * are summed. [bytesPerSecond] guards against treating that as a traffic spike by
+ * comparing a source key derived from the current interface set: if it differs
+ * from the previous sample's, the measurement is rebaselined (reported as 0)
+ * instead of diffing two unrelated counters.
+ */
 class TrafficSnapshot (
     private val scope: CoroutineScope,
     private val appPreferenceRepo: AppPreferenceRepo,
@@ -51,30 +81,36 @@ class TrafficSnapshot (
     @Volatile private var lastUp: Long = 0
     @Volatile private var currentDown: Long = 0
     @Volatile private var currentUp: Long = 0
+    @Volatile private var lastSourceKey: String = ""
+    @Volatile private var currentSourceKey: String = ""
+    @Volatile private var lastElapsedRealtimeMs: Long = SystemClock.elapsedRealtime()
+    @Volatile private var currentElapsedRealtimeMs: Long = lastElapsedRealtimeMs
     @Volatile private var useFallback: Boolean = TrafficStats.getTotalTxBytes() == TrafficStats.UNSUPPORTED.toLong()
-    @Volatile private var altVpnWorkaround: Boolean = false
 
     init {
-        combine(appPreferenceRepo.forceFallback, appPreferenceRepo.altVpn) { force, alt ->
-            useFallback = force || TrafficStats.getTotalTxBytes() == TrafficStats.UNSUPPORTED.toLong()
-            altVpnWorkaround = alt
-        }.launchIn(scope)
+        appPreferenceRepo.forceFallback
+            .onEach { force -> useFallback = force || TrafficStats.getTotalTxBytes() == TrafficStats.UNSUPPORTED.toLong() }
+            .launchIn(scope)
     }
+
     val totalSpeed: Long
         get() = upSpeed + downSpeed
 
     val upSpeed: Long
-        get() = currentUp - lastUp
+        get() = bytesPerSecond(currentUp, lastUp, currentSourceKey, lastSourceKey, currentElapsedRealtimeMs, lastElapsedRealtimeMs)
 
     val downSpeed: Long
-        get() = currentDown - lastDown
+        get() = bytesPerSecond(currentDown, lastDown, currentSourceKey, lastSourceKey, currentElapsedRealtimeMs, lastElapsedRealtimeMs)
 
     fun setCurrentAsLast() {
         lastDown = currentDown
         lastUp = currentUp
+        lastSourceKey = currentSourceKey
+        lastElapsedRealtimeMs = currentElapsedRealtimeMs
     }
 
     suspend fun updateSnapshot() {
+        currentElapsedRealtimeMs = SystemClock.elapsedRealtime()
         if (useFallback) {
             try {
                 fallbackUpdateSnapshot()
@@ -93,32 +129,67 @@ class TrafficSnapshot (
     }
 
     private suspend fun regularUpdateSnapshot() = withContext(Dispatchers.IO) {
-        val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
-        val runVpnWorkaround = (capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ?: false)
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-
-        if (runVpnWorkaround) {
-            if (altVpnWorkaround) {
-                currentDown = TrafficStats.getRxBytes("tun0")
-                currentUp = TrafficStats.getTxBytes("tun0")
-            } else { // More accurate, but breaks split tunneling setups
-                currentDown = TrafficStats.getTotalRxBytes() - TrafficStats.getRxBytes("tun0")
-                currentUp = TrafficStats.getTotalTxBytes() - TrafficStats.getTxBytes("tun0")
-            }
-        } else {
+        val interfaces = physicalInterfaceNames()
+        if (interfaces.isEmpty()) {
+            // No physical (Wi-Fi/cellular/Ethernet) network is visible to this app right
+            // now - can happen transiently during a network handover, or on an unusual
+            // setup where only a VPN network is reported. Total counters are the best
+            // remaining source, even though they can double-count VPN traffic; there is
+            // no physical-only source left to fall back to.
+            currentSourceKey = SOURCE_TOTAL
             currentDown = TrafficStats.getTotalRxBytes()
             currentUp = TrafficStats.getTotalTxBytes()
+            return@withContext
         }
 
-        /**
-         * Fun fact: when switching networks the api sometimes messes up the values as per
-         * https://issuetracker.google.com/issues/37009612
-         * Yes. That bug report is from 2014.
-         * Yes. It still happens on my Android 16 device.
-         */
+        currentSourceKey = interfaces.sorted().joinToString(",")
+        currentDown = interfaces.sumOf { it.rxBytesOrZero() }
+        currentUp = interfaces.sumOf { it.txBytesOrZero() }
+
+        // Fun fact: when switching networks the API sometimes messes up the values as per
+        // https://issuetracker.google.com/issues/37009612
+        // Yes. That bug report is from 2014.
+        // Yes. It still happens on recent Android versions.
+        // The source-key rebaseline in bytesPerSecond() covers a network switch changing
+        // which interfaces are summed, but not this: a transient bad reading from the
+        // platform itself on the interfaces we're already tracking.
     }
 
+    /**
+     * Interfaces backing the device's currently connected physical networks
+     * (Wi-Fi, cellular, Ethernet), discovered via [ConnectivityManager] instead of
+     * assumed names, so this keeps working on devices where those names differ
+     * and stays correct across VPN connect/disconnect: a VPN's own tunnel network
+     * always reports `TRANSPORT_VPN` and is excluded, while the physical network
+     * underneath it keeps being reported on its own, without that transport.
+     *
+     * `allNetworks` is deprecated in favor of a registered [ConnectivityManager]
+     * callback, but this class is a polling snapshot by design (matching the
+     * notification's own poll loop), so a callback-based rewrite isn't warranted
+     * here; the deprecated call remains fully functional.
+     */
+    @Suppress("DEPRECATION")
+    private fun physicalInterfaceNames(): List<String> =
+        connectivityManager.allNetworks
+            .mapNotNull { network ->
+                val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return@mapNotNull null
+                val isPhysical = !capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN) &&
+                        (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+                                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
+                                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET))
+                if (!isPhysical) return@mapNotNull null
+                connectivityManager.getLinkProperties(network)?.interfaceName
+            }
+            .distinct()
+
+    private fun String.rxBytesOrZero(): Long =
+        TrafficStats.getRxBytes(this).let { if (it == TrafficStats.UNSUPPORTED.toLong()) 0L else it }
+
+    private fun String.txBytesOrZero(): Long =
+        TrafficStats.getTxBytes(this).let { if (it == TrafficStats.UNSUPPORTED.toLong()) 0L else it }
+
     private fun fallbackUpdateSnapshot() {
+        currentSourceKey = SOURCE_FALLBACK
         val mobileUp = mobileTxFile.readLongOrZero()
         val mobileDown = mobileRxFile.readLongOrZero()
         val wifiUp = wifiTxFile.readLongOrZero() + ethTxFile.readLongOrZero()
@@ -132,6 +203,9 @@ class TrafficSnapshot (
     private fun File.readLongOrZero() = if (canRead()) readText().trim().toLong() else 0L
 
     companion object {
+        private const val SOURCE_TOTAL = "total"
+        private const val SOURCE_FALLBACK = "fallback"
+
         private val mobileRxFile: File by lazy { File("/sys/class/net/rmnet0/statistics/rx_bytes") }
         private val mobileTxFile: File by lazy { File("/sys/class/net/rmnet0/statistics/tx_bytes") }
         private val wifiRxFile: File by lazy { File("/sys/class/net/wlan0/statistics/rx_bytes") }
@@ -140,4 +214,35 @@ class TrafficSnapshot (
         private val ethTxFile: File by lazy { File("/sys/class/net/eth0/statistics/tx_bytes") }
         fun doesFallbackWork(): Boolean = mobileRxFile.canRead() || wifiRxFile.canRead() || ethRxFile.canRead()
     }
+}
+
+/**
+ * Converts two counter samples into an instantaneous bytes-per-second rate.
+ *
+ * Returns 0 instead of a computed rate when:
+ * - there is no previous sample yet ([lastSourceKey] empty on the very first call),
+ * - the measurement source changed between samples (interface handover, VPN
+ *   attaching/detaching from the physical interface set, fallback mode toggling) -
+ *   the two counters aren't comparable, so this rebaselines instead of reporting
+ *   whatever gap happens to exist between two unrelated counters,
+ * - the counter went backwards (device reboot, a driver resetting its interface
+ *   counters, counter wraparound) - this never derives a negative or
+ *   overflow-driven speed from that.
+ *
+ * Elapsed time is measured directly rather than assumed, since the actual gap
+ * between samples varies with scheduling delays.
+ */
+internal fun bytesPerSecond(
+    currentBytes: Long,
+    lastBytes: Long,
+    currentSourceKey: String,
+    lastSourceKey: String,
+    currentElapsedRealtimeMs: Long,
+    lastElapsedRealtimeMs: Long,
+): Long {
+    if (currentSourceKey != lastSourceKey) return 0L
+    val deltaBytes = currentBytes - lastBytes
+    if (deltaBytes <= 0L) return 0L
+    val elapsedMs = (currentElapsedRealtimeMs - lastElapsedRealtimeMs).coerceAtLeast(1L)
+    return (deltaBytes.toDouble() * 1000.0 / elapsedMs).toLong()
 }

--- a/app/src/main/java/com/leekleak/trafficlight/ui/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/leekleak/trafficlight/ui/settings/NotificationSettingsScreen.kt
@@ -130,15 +130,6 @@ private fun BehaviorSettings() {
         onValueChanged = { scope.launch { appPreferenceRepo.setModeAOD(it) } }
     )
 
-    val altVpn by appPreferenceRepo.altVpn.collectAsState(false)
-    SwitchPreference(
-        title = stringResource(R.string.alt_vpn_workaround),
-        summary = stringResource(R.string.alt_vpn_workaround_description),
-        icon = painterResource(R.drawable.vpn),
-        value = altVpn,
-        onValueChanged = { scope.launch { appPreferenceRepo.setAltVpn(it) } }
-    )
-
     val forceFallback by appPreferenceRepo.forceFallback.collectAsState(false)
     val doesFallbackWork = remember { TrafficSnapshot.doesFallbackWork() }
     SwitchPreference(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">مجهول</string>
     <string name="appearance">المظهر</string>
     <string name="behavior">السلوك</string>
-    <string name="alt_vpn_workaround">حل بديل لـ VPN</string>
-    <string name="alt_vpn_workaround_description">دقة أفضل، لكنه لا يعمل عند استخدام التقسيم النفقي.</string>
     <string name="shizuku_not_running">Shizuku لا يعمل</string>
     <string name="sim_card">بطاقة SIM</string>
     <string name="data_plans">خطط البيانات</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -36,8 +36,6 @@
     <string name="unknown">نەزانراو</string>
     <string name="appearance">ڕووکار</string>
     <string name="behavior">ڕەفتار</string>
-    <string name="alt_vpn_workaround">ڕێگەچارەی جێگرەوەی VPN</string>
-    <string name="alt_vpn_workaround_description">وردیی پێوانەکردن کەمدەکاتەوە بەڵام ڕێگە بە تونێلکردنی جیاکەرەوە دەدات.</string>
     <string name="shizuku_not_running">شیزوکو کار ناکات</string>
     <string name="sim_card">سیم کارد</string>
     <string name="data_plans">پلانەکانی داتا</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">Unbekannt</string>
     <string name="appearance">Aussehen</string>
     <string name="behavior">Verhalten</string>
-    <string name="alt_vpn_workaround">Alternative VPN-Lösung</string>
-    <string name="alt_vpn_workaround_description">Verbessert die Genauigkeit, unterbricht jedoch das Split-Tunneling.</string>
     <string name="shizuku_not_running">Shizuku läuft nicht</string>
     <string name="sim_card">SIM-Karte</string>
     <string name="data_plans">Datenpläne</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">Desconocido</string>
     <string name="appearance">Apariencia</string>
     <string name="behavior">Comportamiento</string>
-    <string name="alt_vpn_workaround">Solución alternativa de VPN</string>
-    <string name="alt_vpn_workaround_description">Mejor precisión pero no funcionará cuando desglose tunelización.</string>
     <string name="shizuku_not_running">Shizuku no está en ejecución.</string>
     <string name="sim_card">Tarjeta SIM</string>
     <string name="data_plans">Planes de datos</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -35,6 +35,4 @@
     <string name="unknown">ناشناخته</string>
     <string name="appearance">ظاهر</string>
     <string name="behavior">رفتار</string>
-    <string name="alt_vpn_workaround">راهکار جایگزین فیلترشکن</string>
-    <string name="alt_vpn_workaround_description">دقت اندازه‌گیری را کاهش می‌دهد، اما با تونل‌بندی تفکیکی سازگار است.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">Inconnu</string>
     <string name="appearance">Apparence</string>
     <string name="behavior">Comportement</string>
-    <string name="alt_vpn_workaround">Contournement VPN alternatif</string>
-    <string name="alt_vpn_workaround_description">Améliore la précision mais ne fonctionne pas avec les tunnels séparés.</string>
     <string name="shizuku_not_running">Shizuku n\'est pas lancé</string>
     <string name="sim_card">Carte SIM</string>
     <string name="data_plans">Forfaits de données</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">Descoñecido</string>
     <string name="appearance">aparencia</string>
     <string name="behavior">Comportamento</string>
-    <string name="alt_vpn_workaround">Solución alternativa pra a VPN</string>
-    <string name="alt_vpn_workaround_description">Mellora precisión das medicións, pero rompe o túnel dividido (Split Tunneling).</string>
     <string name="shizuku_not_running">Shizuku non está en execución</string>
     <string name="sim_card">Tarxeta SIM</string>
     <string name="data_plans">Plans de datos</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">Tidak diketahui</string>
     <string name="appearance">Tampilan</string>
     <string name="behavior">Perilaku</string>
-    <string name="alt_vpn_workaround">Solusi alternatif VPN</string>
-    <string name="alt_vpn_workaround_description">Akurasi yang lebih baik tetapi tidak akan berfungsi saat menggunakan tunneling terpisah.</string>
     <string name="shizuku_not_running">Shizuku tidak berjalan</string>
     <string name="sim_card">Kartu SIM</string>
     <string name="data_plans">Paket Data</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -36,8 +36,6 @@
     <string name="unknown">Sconosciuto</string>
     <string name="appearance">Aspetto</string>
     <string name="behavior">Comportamento</string>
-    <string name="alt_vpn_workaround">Soluzione alternativa per VPN</string>
-    <string name="alt_vpn_workaround_description">Migliora la precisione ma interrompe la tecnica del tunneling diviso.</string>
     <string name="shizuku_not_running">Shizuku non è in esecuzione</string>
     <string name="sim_card">Scheda SIM</string>
     <string name="data_plans">Piani Dati</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -33,8 +33,6 @@
     <string name="total_usage">総使用量</string>
     <string name="unknown">不明</string>
     <string name="app_name">Traffic Light：ネットワークトラッカー</string>
-    <string name="alt_vpn_workaround_description">精度は向上しますが、スプリットトンネル機能が損なわれます。</string>
-    <string name="alt_vpn_workaround">代替VPNの回避策</string>
     <string name="behavior">行動</string>
     <string name="appearance">外観</string>
     <string name="shizuku_not_running">Shizukuが起動していません</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">Nežinoma</string>
     <string name="appearance">Išvaizda</string>
     <string name="behavior">Elgsena</string>
-    <string name="alt_vpn_workaround">Alternatyvus VPN duomenų skaičiavimas</string>
-    <string name="alt_vpn_workaround_description">Tikslesni matavimai, tačiau neveikia naudojant kelių tunelių konfigūracijos VPN.</string>
     <string name="shizuku_not_running">Shizuku nepaleistas</string>
     <string name="sim_card">SIM kortelė</string>
     <string name="data_plans">Duomenų Planai</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">Onbekend</string>
     <string name="appearance">Uiterlijk</string>
     <string name="behavior">Gedrag</string>
-    <string name="alt_vpn_workaround">Alternatieve VPN-omzeiling</string>
-    <string name="alt_vpn_workaround_description">Betere nauwkeurigheid, maar zal niet werken met split tunnels.</string>
     <string name="shizuku_not_running">Shizuku loopt niet</string>
     <string name="sim_card">Simkaart</string>
     <string name="data_plans">Databundels</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">Nieznane</string>
     <string name="appearance">Wygląd</string>
     <string name="behavior">Zachowanie</string>
-    <string name="alt_vpn_workaround">Alternatywne obejście VPN</string>
-    <string name="alt_vpn_workaround_description">Zmniejsza dokładność pomiarów, ale umożliwia stosowanie tunelowania dzielonego.</string>
     <string name="shizuku_not_running">Shizuku nie jest uruchomione.</string>
     <string name="sim_card">Karta SIM</string>
     <string name="data_plans">Pakiety danych</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -44,8 +44,6 @@
     <string name="unknown">Desconhecido</string>
     <string name="appearance">Aparência</string>
     <string name="behavior">Comportamento</string>
-    <string name="alt_vpn_workaround">Solução alternativa para VPN</string>
-    <string name="alt_vpn_workaround_description">Reduz a precisão da medição, mas oferece suporte a Split Tunneling.</string>
     <string name="shizuku_not_running">Shizuku não está em execução.</string>
     <string name="sim_card">Cartão SIM</string>
     <string name="data_plans">Planos de Dados</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -35,7 +35,6 @@
     <string name="unknown">Desconhecido</string>
     <string name="appearance">Aparência</string>
     <string name="behavior">Comportamento</string>
-    <string name="alt_vpn_workaround">Solução alternativa da VPN</string>
     <string name="app_name_short">Traffic Light</string>
     <string name="shizuku_not_running">Shizuku não foi iniciado</string>
     <string name="sim_card">Cartão SIM</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -35,8 +35,6 @@
     <string name="appearance">Aspect</string>
     <string name="total_usage">Utilizare totală</string>
     <string name="behavior">Comportament</string>
-    <string name="alt_vpn_workaround">Soluții alternative pentru VPN</string>
-    <string name="alt_vpn_workaround_description">Îmbunătățește precizia, dar întrerupe tunelul divizat.</string>
     <string name="shizuku_not_running">Shizuku nu rulează</string>
     <string name="sim_card">Card SIM</string>
     <string name="data_plans">Planuri de date</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -36,8 +36,6 @@
     <string name="unknown">Неизвестно</string>
     <string name="appearance">Внешний вид</string>
     <string name="behavior">Поведение</string>
-    <string name="alt_vpn_workaround">Чередовать обход VPN</string>
-    <string name="alt_vpn_workaround_description">Улучшает точность но ломает split tunneling (раздельное туннелирование).</string>
     <string name="shizuku_not_running">Shizuku не запущен</string>
     <string name="sim_card">SIM карта</string>
     <string name="data_plans">Тарифные планы</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">Bilinmeyen</string>
     <string name="appearance">Görünüm</string>
     <string name="behavior">Davranış</string>
-    <string name="alt_vpn_workaround">Alternatif VPN geçici çözümü</string>
-    <string name="alt_vpn_workaround_description">Daha yüksek doğruluk sağlar ancak bölünmüş tünelleme durumunda çalışmaz.</string>
     <string name="shizuku_not_running">Shizuku aktif değil</string>
     <string name="sim_card">SIM kart</string>
     <string name="data_plans">Veri Planları</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -35,8 +35,6 @@
     <string name="unknown">未知</string>
     <string name="appearance">外观</string>
     <string name="behavior">行为</string>
-    <string name="alt_vpn_workaround">替代性VPN计算方法</string>
-    <string name="alt_vpn_workaround_description">精度更高，但在分流隧道模式下无效。</string>
     <string name="shizuku_not_running">Shizuku未运行</string>
     <string name="sim_card">SIM卡</string>
     <string name="data_plans">数据计划</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -45,8 +45,6 @@
     <string name="unknown">未知程式</string>
     <string name="behavior">行為</string>
     <string name="appearance">外觀</string>
-    <string name="alt_vpn_workaround">VPN替代模式</string>
-    <string name="alt_vpn_workaround_description">支援隧道分離模式(split tunneling)，但計算精確性較低。</string>
     <string name="total_usage">總計使用量</string>
     <string name="notification_description">於狀態列中顯示網路速度。</string>
     <string name="auto">自動</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,8 +44,6 @@
     <string name="unknown">Unknown</string>
     <string name="appearance">Appearance</string>
     <string name="behavior">Behavior</string>
-    <string name="alt_vpn_workaround">Alternate VPN workaround</string>
-    <string name="alt_vpn_workaround_description">Better accuracy but will not work when split tunneling.</string>
     <string name="donate">Donate</string>
     <string name="shizuku_not_running">Shizuku is not running</string>
     <string name="sim_card">SIM card</string>

--- a/app/src/test/java/com/leekleak/trafficlight/database/BytesPerSecondTest.kt
+++ b/app/src/test/java/com/leekleak/trafficlight/database/BytesPerSecondTest.kt
@@ -1,0 +1,107 @@
+package com.leekleak.trafficlight.database
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-function tests for the counter-delta -> speed arithmetic used by
+ * [TrafficSnapshot]. No Android framework dependency, so these run as plain
+ * JVM unit tests without Robolectric.
+ */
+class BytesPerSecondTest {
+
+    @Test
+    fun `normal case divides delta by actual elapsed time`() {
+        // previous RX = 1000, current RX = 3000, elapsed = 1s -> 2000 bytes/sec
+        val speed = bytesPerSecond(
+            currentBytes = 3000L, lastBytes = 1000L,
+            currentSourceKey = "wlan0", lastSourceKey = "wlan0",
+            currentElapsedRealtimeMs = 1000L, lastElapsedRealtimeMs = 0L,
+        )
+        assertEquals(2000L, speed)
+    }
+
+    @Test
+    fun `long sampling interval uses actual elapsed time, not an assumed one`() {
+        // 1830ms elapsed instead of the "expected" 1000ms.
+        val speed = bytesPerSecond(
+            currentBytes = 1830L, lastBytes = 0L,
+            currentSourceKey = "wlan0", lastSourceKey = "wlan0",
+            currentElapsedRealtimeMs = 1830L, lastElapsedRealtimeMs = 0L,
+        )
+        assertEquals(1000L, speed)
+    }
+
+    @Test
+    fun `first sample has no previous source and produces no spike`() {
+        val speed = bytesPerSecond(
+            currentBytes = 5_000_000L, lastBytes = 0L,
+            currentSourceKey = "wlan0", lastSourceKey = "", // no prior sample yet
+            currentElapsedRealtimeMs = 1000L, lastElapsedRealtimeMs = 0L,
+        )
+        assertEquals(0L, speed)
+    }
+
+    @Test
+    fun `changing measurement source rebaselines instead of diffing unrelated counters`() {
+        // e.g. Wi-Fi (10 MB) -> Ethernet (50 GB): must not be read as ~50GB of traffic.
+        val speed = bytesPerSecond(
+            currentBytes = 50_000_000_000L, lastBytes = 10_000_000L,
+            currentSourceKey = "eth0", lastSourceKey = "wlan0",
+            currentElapsedRealtimeMs = 1000L, lastElapsedRealtimeMs = 0L,
+        )
+        assertEquals(0L, speed)
+    }
+
+    @Test
+    fun `counter reset does not produce a negative or overflow-derived speed`() {
+        // e.g. 10 GB -> 100 MB on the same interface (stats reset without reboot).
+        val speed = bytesPerSecond(
+            currentBytes = 100_000_000L, lastBytes = 10_000_000_000L,
+            currentSourceKey = "wlan0", lastSourceKey = "wlan0",
+            currentElapsedRealtimeMs = 1000L, lastElapsedRealtimeMs = 0L,
+        )
+        assertEquals(0L, speed)
+    }
+
+    @Test
+    fun `zero traffic produces zero speed`() {
+        val speed = bytesPerSecond(
+            currentBytes = 42L, lastBytes = 42L,
+            currentSourceKey = "wlan0", lastSourceKey = "wlan0",
+            currentElapsedRealtimeMs = 1000L, lastElapsedRealtimeMs = 0L,
+        )
+        assertEquals(0L, speed)
+    }
+
+    @Test
+    fun `very high throughput does not overflow`() {
+        val tenGigabitPerSecondBytes = 1_250_000_000L
+        val speed = bytesPerSecond(
+            currentBytes = tenGigabitPerSecondBytes, lastBytes = 0L,
+            currentSourceKey = "eth0", lastSourceKey = "eth0",
+            currentElapsedRealtimeMs = 1000L, lastElapsedRealtimeMs = 0L,
+        )
+        assertEquals(tenGigabitPerSecondBytes, speed)
+    }
+
+    @Test
+    fun `zero elapsed time is clamped instead of dividing by zero`() {
+        val speed = bytesPerSecond(
+            currentBytes = 100L, lastBytes = 0L,
+            currentSourceKey = "wlan0", lastSourceKey = "wlan0",
+            currentElapsedRealtimeMs = 500L, lastElapsedRealtimeMs = 500L,
+        )
+        // Elapsed clamped to 1ms -> 100 bytes / 1ms = 100_000 bytes/sec; the point of
+        // this test is only that it returns a finite value instead of crashing.
+        assertEquals(100_000L, speed)
+    }
+
+    @Test
+    fun `upload and download are computed independently`() {
+        val down = bytesPerSecond(2000L, 1000L, "wlan0", "wlan0", 1000L, 0L)
+        val up = bytesPerSecond(1300L, 1000L, "wlan0", "wlan0", 1000L, 0L)
+        assertEquals(1000L, down)
+        assertEquals(300L, up)
+    }
+}

--- a/app/src/test/java/com/leekleak/trafficlight/database/TrafficSnapshotTest.kt
+++ b/app/src/test/java/com/leekleak/trafficlight/database/TrafficSnapshotTest.kt
@@ -1,0 +1,143 @@
+package com.leekleak.trafficlight.database
+
+import android.net.ConnectivityManager
+import android.net.LinkProperties
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.TrafficStats
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import java.time.Duration
+
+/**
+ * Covers the two failure modes the original implementation was prone to:
+ * counting VPN/tunnel traffic on top of the physical interface it rides on
+ * (double counting -> inflated speed), and treating a change of measurement
+ * source (interface handover, or a newly appearing/disappearing counter) as
+ * if it were real traffic (a spike).
+ *
+ * [BytesPerSecondTest] covers the counter-delta arithmetic directly with no
+ * Android/Robolectric dependency. This class instead drives
+ * [TrafficSnapshot] through its real public API with a mocked
+ * [ConnectivityManager], to check the interface discovery and VPN exclusion
+ * that arithmetic relies on.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class TrafficSnapshotTest {
+
+    private lateinit var connectivityManager: ConnectivityManager
+    private lateinit var appPreferenceRepo: AppPreferenceRepo
+
+    @Before
+    fun setUp() {
+        mockkStatic(TrafficStats::class)
+        every { TrafficStats.getTotalTxBytes() } returns 0L
+        every { TrafficStats.getTotalRxBytes() } returns 0L
+
+        connectivityManager = mockk()
+        appPreferenceRepo = mockk(relaxed = true)
+        every { appPreferenceRepo.forceFallback } returns flowOf(false)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(TrafficStats::class)
+    }
+
+    private fun networkWith(interfaceName: String, vararg transports: Int): Network {
+        val network = mockk<Network>()
+        val capabilities = mockk<NetworkCapabilities>()
+        val transportSet = transports.toSet()
+        every { capabilities.hasTransport(any()) } answers { transportSet.contains(firstArg<Int>()) }
+        val linkProperties = mockk<LinkProperties>()
+        every { linkProperties.interfaceName } returns interfaceName
+        every { connectivityManager.getNetworkCapabilities(network) } returns capabilities
+        every { connectivityManager.getLinkProperties(network) } returns linkProperties
+        return network
+    }
+
+    @Test
+    fun `VPN interface traffic is excluded from the physical interface sum`() = runTest {
+        val wifi = networkWith("wlan0", NetworkCapabilities.TRANSPORT_WIFI)
+        val vpn = networkWith("tun0", NetworkCapabilities.TRANSPORT_VPN)
+        every { connectivityManager.allNetworks } returns arrayOf(wifi, vpn)
+
+        // wlan0 carries the (larger, encrypted) physical traffic; tun0 carries the
+        // same logical traffic again, decrypted. Only wlan0 should be counted.
+        every { TrafficStats.getRxBytes("wlan0") } returnsMany listOf(1_000_000L, 1_200_000L)
+        every { TrafficStats.getTxBytes("wlan0") } returnsMany listOf(500_000L, 600_000L)
+        every { TrafficStats.getRxBytes("tun0") } returnsMany listOf(950_000L, 1_140_000L)
+        every { TrafficStats.getTxBytes("tun0") } returnsMany listOf(480_000L, 570_000L)
+
+        val snapshot = TrafficSnapshot(this, appPreferenceRepo, connectivityManager)
+        snapshot.updateSnapshot()
+        snapshot.setCurrentAsLast()
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(1))
+        snapshot.updateSnapshot()
+
+        // wlan0-only delta: +200,000 down, +100,000 up over 1s.
+        // If tun0 had leaked into the sum this would be 390,000 / 190,000 instead.
+        assertEquals(200_000L, snapshot.downSpeed)
+        assertEquals(100_000L, snapshot.upSpeed)
+    }
+
+    @Test
+    fun `switching physical interface rebaselines instead of spiking`() = runTest {
+        val wifi = networkWith("wlan0", NetworkCapabilities.TRANSPORT_WIFI)
+        val cellular = networkWith("rmnet0", NetworkCapabilities.TRANSPORT_CELLULAR)
+
+        every { TrafficStats.getRxBytes("wlan0") } returns 10_000_000L
+        every { TrafficStats.getTxBytes("wlan0") } returns 1_000_000L
+        every { TrafficStats.getRxBytes("rmnet0") } returns 50_000_000_000L
+        every { TrafficStats.getTxBytes("rmnet0") } returns 5_000_000_000L
+
+        val snapshot = TrafficSnapshot(this, appPreferenceRepo, connectivityManager)
+
+        every { connectivityManager.allNetworks } returns arrayOf(wifi)
+        snapshot.updateSnapshot()
+        snapshot.setCurrentAsLast()
+
+        // Wi-Fi disappears, mobile (with an unrelated, much larger cumulative
+        // counter) takes over as the only physical network.
+        every { connectivityManager.allNetworks } returns arrayOf(cellular)
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(1))
+        snapshot.updateSnapshot()
+
+        // Must not report ~50GB-10MB worth of "speed" from the handover.
+        assertEquals(0L, snapshot.downSpeed)
+        assertEquals(0L, snapshot.upSpeed)
+    }
+
+    @Test
+    fun `no physical network falls back to device totals rather than crashing`() = runTest {
+        every { connectivityManager.allNetworks } returns arrayOf()
+        // Constant regardless of call count, so this stays deterministic no matter
+        // how many times the flow collector in TrafficSnapshot's init block reads it.
+        every { TrafficStats.getTotalTxBytes() } returns 0L
+        every { TrafficStats.getTotalRxBytes() } returnsMany listOf(2_000L, 2_500L)
+
+        val snapshot = TrafficSnapshot(this, appPreferenceRepo, connectivityManager)
+        snapshot.updateSnapshot()
+        snapshot.setCurrentAsLast()
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(1))
+        snapshot.updateSnapshot()
+
+        assertEquals(500L, snapshot.downSpeed)
+        assertEquals(0L, snapshot.upSpeed)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes inflated network speed readings when traffic is routed through VPN or local VPN interfaces.

The previous implementation derived physical traffic from device-wide counters using special handling for a hardcoded `tun0` interface. Depending on Android's traffic accounting, the same traffic could be counted at both the physical and VPN layers, resulting in inflated speed readings.

The app previously exposed an **Alternate VPN workaround** setting with two different strategies:

- Read traffic directly from `tun0`
- Subtract `tun0` traffic from device-wide traffic totals

Neither approach was universally reliable. VPN interface names are not guaranteed to be `tun0`, and subtracting VPN traffic from device-wide counters still depends on how Android accounts traffic across the physical and virtual interfaces. This could still produce inaccurate or inflated readings.

This PR replaces those workaround strategies with physical-interface-based traffic measurement.

## Changes

- Discover physical Wi-Fi, cellular, and Ethernet interfaces dynamically
- Exclude `TRANSPORT_VPN` networks from the primary measurement path
- Resolve interface names through `LinkProperties.interfaceName`
- Remove the hardcoded `tun0` dependency
- Measure traffic directly from the selected physical interfaces
- Rebaseline measurements when the active interface set changes to prevent transition spikes
- Calculate speed using the actual elapsed time between samples
- Handle counter resets and non-positive deltas safely
- Remove the obsolete Alternate VPN workaround setting and related translations
- Add tests for speed calculation, source changes, counter resets, and VPN interface exclusion

## Testing

Tested with a local VPN-based traffic filtering application enabled.

Previously, the indicator could report significantly inflated speeds compared with the actual network throughput, and the existing VPN workaround options did not reliably resolve the issue.

With this change, the displayed upload and download speeds match the observed network throughput and no longer show the previously observed VPN-related inflation.

## Related issue

Closes #214 